### PR TITLE
Fix invalid semver in package.json to fix yarn v2/3 installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@lottiefiles/lottie-player": "^1.04",
+    "@lottiefiles/lottie-player": "^1.0.4",
     "vue": "^2.6.12"
   },
   "devDependencies": {


### PR DESCRIPTION
The semver for lottie-player was `^1.04" which is invalid because it's missing the dot before the patch version. This was breaking installs for Yarn v2 and 3. Correcting the semver to "^v1.0.4" allows the install to complete without actually changing the dependency version. 

Resolves #14 