### PR TITLE
fix: stopped reseting to start when not looping

### DIFF
--- a/.changeset/silver-pets-fold.md
+++ b/.changeset/silver-pets-fold.md
@@ -1,0 +1,5 @@
+---
+"@lottiefiles/vue-lottie-player": patch
+---
+
+removed reset if not looping

--- a/example/components/Home.vue
+++ b/example/components/Home.vue
@@ -14,7 +14,7 @@
       :player-size="options.playerSize"
       :player-controls="true"
       :showColorPicker="true"
-      :loop="true"
+      :loop="false"
       :speed="3"
       :autoplay="true"
       mode="normal"

--- a/src/Player.vue
+++ b/src/Player.vue
@@ -179,12 +179,6 @@ export default {
         this.loading = false;
       }.bind(this)
     );
-    this.player.addEventListener(
-      "complete",
-      function () {
-        this.stop();
-      }.bind(this)
-    );
     this.options.backgroundColor = this.backgroundColor;
     this.options.speed = this.speed;
     this.options.loop = this.loop;


### PR DESCRIPTION
Fix:

Removed stop() call when finished looping, when loop = false it will no longer go to the start frame.