### PR TITLE
changed bg-white to lf-bg-white

### DIFF
--- a/.changeset/pink-islands-marry.md
+++ b/.changeset/pink-islands-marry.md
@@ -1,0 +1,5 @@
+---
+"@lottiefiles/vue-lottie-player": minor
+---
+
+Changed "bg-white" css class to "lf-bg-white" to avoid conflicts with other libraries

--- a/src/Controls.vue
+++ b/src/Controls.vue
@@ -107,7 +107,7 @@
         class="lf-mx-2 lf-flex lf-items-center cursor-pointer"
       >
         <span
-          class="lf-min-w-8 bg-white lf-border lf-border-grey-light lf-px-1 lf-py-1 lf-rounded-md text-grey-darkest lf-text-xs lf-text-center font-lf"
+          class="lf-min-w-8 lf-bg-white lf-border lf-border-grey-light lf-px-1 lf-py-1 lf-rounded-md text-grey-darkest lf-text-xs lf-text-center font-lf"
           >{{ speeds[activeSpeedIndex] }}x</span
         >
       </div>
@@ -223,7 +223,7 @@
               <input
                 @keyup="updateBackgroundColor"
                 v-model="backgroundColor"
-                class="lf-w-full text-grey-dark lf-border lf-border-grey-light bg-white lf-px-3 lf-py-2 lf-rounded-md outline-none"
+                class="lf-w-full text-grey-dark lf-border lf-border-grey-light lf-bg-white lf-px-3 lf-py-2 lf-rounded-md outline-none"
                 style="font-size: 100%; box-sizing: border-box"
                 type="text"
               />

--- a/src/Seeker.vue
+++ b/src/Seeker.vue
@@ -30,12 +30,12 @@
     />
     <div class="w-full lf-relative" :style="{ top: '10px' }">
       <span
-        :class="theme.active ? 'bg-white' : ''"
+        :class="theme.active ? 'lf-bg-white' : ''"
         class="lf-min-w-6 lf-absolute lf-pin-l lf-border lf-border-grey-light lf-px-1 lf-py-2px lf-rounded-md text-grey-darkest lf-text-xs lf-text-center font-lf"
         >{{ getCurrentFrame }}</span
       >
       <span
-        :class="theme.active ? 'bg-white' : ''"
+        :class="theme.active ? 'lf-bg-white' : ''"
         class="lf-min-w-6 lf-absolute lf-pin-r lf-border lf-border-grey-light lf-px-1 lf-py-2px lf-rounded-md text-grey-darkest lf-text-xs lf-text-center font-lf"
         >{{ options.animation.totalFrames }}</span
       >

--- a/src/lottie_player.css
+++ b/src/lottie_player.css
@@ -15,7 +15,7 @@
   background-color: #f8fafc;
 }
 
-.bg-white {
+.lf-bg-white {
   background-color: #fff;
 }
 


### PR DESCRIPTION
In some cases, the "bg-white" class overrides the css classes of other libraries (eg Tailwind CSS). In my opinion, the best solution is also to standardize the above class to the others, adding the prefix "lf-".