### PR TITLE
feat: support lazy loading lottie-vue component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,4 +7,5 @@ const LottieVuePlayer = {
   },
 };
 
+export { Player } from "./Player.vue";
 export default LottieVuePlayer;


### PR DESCRIPTION
It's not possible to lazy load a plugin in Vue, but you can lazy load components if exported. 

This PR supports lazy loading by exporting the Player component and the default plugin export.

With this change, you can load lottie-vue on-demand like so:

```vue
<script>
export default {
  components: {
    'lottie-vue-player': () => import('@lottiefiles/vue-lottie-player').then(m => m.Player)
  }
}
</script>

<template>
  <p class="greeting">{{ greeting }}</p>
</template>

<style>
.greeting {
  color: red;
  font-weight: bold;
}
</style>
```