### PR TITLE
chore: add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
-## LottiePlayer Vue Component
+> [!IMPORTANT]
+> **This package (`@lottiefiles/vue-lottie-player`) is deprecated and no longer maintained.**
+> Please use [`@lottiefiles/dotlottie-vue`](https://npmjs.com/package/@lottiefiles/dotlottie-vue) instead.
+>
+> - **npm**: https://npmjs.com/package/@lottiefiles/dotlottie-vue
+> - **GitHub**: https://github.com/lottiefiles/dotlottie-web
+
+---
+
+## LottiePlayer Vue Component (Deprecated)
 
 This is a Vue component for the Lottie Web Player. This library is a vue wrapper around the LottieFiles Lottie Web Player
 


### PR DESCRIPTION
## Summary

- Added a deprecation notice to the top of the README using GitHub admonition syntax
- The notice directs users to `@lottiefiles/dotlottie-vue` as the maintained replacement, with links to npm and GitHub
- Appended "(Deprecated)" to the main heading
- Added a horizontal rule separating the notice from the rest of the README